### PR TITLE
Actualitza Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,8 +25,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.16.3)
     forwardable-extended (2.6.0)
-    google-protobuf (4.26.1-x86_64-linux)
-      rake (>= 13)
+    google-protobuf (3.25.3-x86_64-linux)
     html-proofer (4.4.3)
       addressable (~> 2.3)
       mercenary (~> 0.3)
@@ -94,8 +93,8 @@ GEM
     rexml (3.2.6)
     rouge (4.2.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.72.0)
-      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.69.5)
+      google-protobuf (~> 3.23)
       rake (>= 13.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -118,4 +117,4 @@ DEPENDENCIES
   wdm (~> 0.1.1)
 
 BUNDLED WITH
-   2.5.7
+   2.2.33


### PR DESCRIPTION
El fitxer s'ha generat executant bundle install amb ruby 3.0. El problema es que si es genera el fitxer Gemfile.lock fent servir una versió més nova de ruby (ex, 3.2), bundler agafa versions més noves d'algunes dependencies i aquestes dependencies tenen a la vegada la restrició de que no funcionen amb ruby 3.0.

Una altre opció si no fa fer build amb la versió 3.0 de ruby seria treure-la del fitxer .github/workflows/ci.yml

## Type of change
<!-- Please select the desired item checkbox and change it from `[ ]` to `[x]` and then delete the irrelevant options. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (refactoring and improving code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Description
<!--
  Please include a summary of the change and which issue is fixed. 
  Please also include relevant motivation and context. 
  List any dependencies that are required for this change.
-->

## Additional context
<!-- e.g. Fixes #(issue) -->
